### PR TITLE
Update SLURM_Snake to use a working directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,17 +110,39 @@ there are 3 containers of interest:
 
 ## 2- sbatch and slurm (work in progress)
    
-   To submit a job to OSC I use the script SLURM_snake
+   To submit a job to OSC I use the script [SLURM_Snake](SLURM_Snake).
+   
+   This script requires passing in:
+   - a data directory to hold all data for a single run
+   - a CSV file that contains details about the image files to process
    
    Usage, connect to the login node
    
    ```ssh <username>@pitzer```
    
-   Then
+   Clone this BGNN_Snakemake repo (if necessary) and cd into the repo.
+   ```
+   git clone git@github.com:hdr-bgnn/BGNN_Snakemake.git
+   cd BGNN_Snakemake
+   ```
+   
+   The SLURM_snake script requires a `snakemake` conda environment. 
+   If you have followed the __Using interactive__ instructions this environment will already exist.
+   If not run the following to load minconda, create the environment, and unload miniconda.
+   ```
+   module load miniconda3/4.10.3-py37
+   conda create -n snakemake -c bioconda -c conda-forge snakemake -y
+   module purge
+   ```
+   
+   The `SLURM_Snake` script should be run with arguments like so:
+   ```
+   sbatch SLURM_Snake <data_directory> <path_to_csv>
+   ```
+   For example if you want to store the data files at the relative path of `data/list_test` and processs `List/list_test.csv` run the following:
    
    ```
-   cd BGNN_Snakemake
-   sbatch SLURM_Snake
+   sbatch SLURM_Snake data/list_test List/list_test.csv
    ```
    
    To check the process
@@ -129,18 +151,12 @@ there are 3 containers of interest:
    
    That's it!
    
-   *Comment*: this script will create :
-   * slurm-job_ID.out (and a directory job_ID)
-   * directory job_ID which contain the results in the form of:
-      - Images/
-      - Cropped/
-      - Metadata/
-      - Segmented/
-      - Snakemake/
-      - list_test.csv
+   *Comment*: this script will create a slurm-job_ID.out log file.
    
-   Problem to solve : 
-   * every job create a new folder
-   * snakemake will lose tract of what has been processed. Need to figure out to a better manage the link between input data output and track.
-   * I had to manullay for .snakemake (~/BGNN_Snakemake/.snakemake/singularity/) containing the singularity image in to the $TMPDIR
-   * Same for ~/BGNN_Snakemake/.cache/torch/hub/checkpoints/se_resnext50_32x4d-a260b3a4.pth
+   The `data_directory` will contain the following directory structure:
+   ```
+   Images/
+   Cropped/
+   Metadata/
+   Segmented/
+   ```

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ there are 3 containers of interest:
    
    The SLURM_snake script requires a `snakemake` conda environment. 
    If you have followed the __Using interactive__ instructions this environment will already exist.
-   If not run the following to load minconda, create the environment, and unload miniconda.
+   If not, run the following to load miniconda, create the environment, and unload miniconda.
    ```
    module load miniconda3/4.10.3-py37
    conda create -n snakemake -c bioconda -c conda-forge snakemake -y

--- a/SLURM_Snake
+++ b/SLURM_Snake
@@ -3,26 +3,52 @@
 #SBATCH --job-name=segment_test
 #SBATCH --time=00:10:00
 #SBATCH --ntasks=4
+#
+# Runs Snakemake pipeline that downloads, crops, and segments images.
+# There are two required positional arguments.
+# Usage:
+# sbatch SLURM_Snake <WORKDIR> <INPUTCSV>
+# - WORKDIR - Snakemake working directory - contains output files
+# - INPUTCSV - Path to input CSV file specifying images to process
 
-module load miniconda3
-conda init
-source ~/.bashrc
+# Stop if a command fails (non-zero exit status)
+set -e
 
-conda activate local
-conda install -c bioconda -c conda-forge snakemake
+# Verify command line arguments
+WORKDIR=$1
+INPUTCSV=$2
 
-cp $SLURM_SUBMIT_DIR/list_test.csv $TMPDIR
-cp -R $SLURM_SUBMIT_DIR/Images $TMPDIR
-cp $SLURM_SUBMIT_DIR/Snakefile $TMPDIR
-cp -R $SLURM_SUBMIT_DIR/.snakemake $TMPDIR
-cp -R $SLURM_SUBMIT_DIR/.cache $TMPDIR
+# Ensures CSV path is an absolute path.
+# Otherwise snakemake will look for this file within $WORKDIR.
+REAL_INPUTCSV=$(realpath $INPUTCSV)
 
-cd $TMPDIR
+# Make sure the input CSV file exists
+if [ ! -f "$REAL_INPUTCSV" ]
+then
+   echo "ERROR: Required INPUTCSV file $INPUTCSV does not exist."
+   exit 1
+fi
 
-snakemake --cores 4 --use-singularity --config list=list_test.csv
+# Specify cache directories
+CACHEDIR=$(realpath .cache)
+# cache singularity images
+SINGULARITY_IMAGE_DIR=$CACHEDIR/singularity
+# cache pytorch files
+export TORCH_HOME=$CACHEDIR/torch
+# ensure pytorch cache directory exists
+mkdir -p $TORCH_HOME
 
-cd $SLURM_SUBMIT_DIR
-mkdir $SLURM_JOB_ID
-cp -R $TMPDIR/* $SLURM_JOB_ID
+# Activate Snakemake environment
+module load miniconda3/4.10.3-py37
+# Activate using source per OSC instructions
+source activate snakemake
 
+# Run pipeline using Snakemake
+snakemake \
+    --cores $SLURM_NTASKS \
+    --use-singularity \
+    --singularity-prefix $SINGULARITY_IMAGE_DIR \
+    --singularity-args "--bind $TORCH_HOME:$TORCH_HOME" \
+    --directory $WORKDIR \
+    --config list=$REAL_INPUTCSV
 

--- a/Snakefile
+++ b/Snakefile
@@ -4,9 +4,8 @@ import glob
 import os
 # pull in all files with .fastq on the end in the 'data' directory.
 
-# list all the file.csv and take the first one
-examples = glob_wildcards('{example}.csv').example[0]
-LIST = config.get('list',f'{examples}.csv')
+LIST = config['list']
+   
 print(f"your are using this list {LIST}")
 
 #df = pd.read_csv(f'{LIST}', sep=',', decimal='.')


### PR DESCRIPTION
Adds two required positional arguments to SLURM_Snake:
- WORKDIR - Working directory for input files
- INPUTCSV - Path to CSV input file to process

Usage for the script:
```
sbatch SLURM_Snake <WORKDIR> <INPUTCSV>
```

For example to use data/test1 as a working directory and process
the test_list.csv file a user would run the following:
```
sbatch SLURM_Snake data/test1 List/list_test.csv
```

When snakemake is called the `--directory $WORKDIR` argument is now
passed.

Additionally the --cores argument now uses $SLURM_NTASKS reusing
the value set earlier via `--ntasks=4`.

**Snakefile changes**

Previously the Snakefile looked for a csv file in the current
directory as a default value. I removed this logic since this caused
problems with the `--directory` argument. Removing this logic
also improves reproducibility.

We now use `source activate snakemake` instead of
`conda activatate snakemake` based on [OSC docs](https://www.osc.edu/resources/getting_started/howto/howto_add_python_packages_using_the_conda_package_manager).

---

**Caching**

Building on the earlier use of '.cache' to cache files this change
stores singularity images and pytorch data within this directory.

**Singularity**
When using the working directory the singularity images were being
cached within that directory. This caused the pipeline to fetch
the sif images for every set of data used. This also wasted space
by keeping a copy of the sif files within the .snakemake directory.
To fix this I added the `--singularity-prefix` argument.

**Pytorch**
The Segmentation step of the pipeline downloads a large pth file.
Similar to the singularity images this was being done for every
set of data processed and wasted space. To cache pytorch files
be specify for singularity to bind $TORCH_HOME with the
 `--singularity-args` argument.

Fixes #7