### PR TITLE
Run snakemake across multiple nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,10 +112,6 @@ there are 3 containers of interest:
    
    To submit a job to OSC I use the script [SLURM_Snake](SLURM_Snake).
    
-   This script requires passing in:
-   - a data directory to hold all data for a single run
-   - a CSV file that contains details about the image files to process
-   
    Usage, connect to the login node
    
    ```ssh <username>@pitzer```
@@ -135,14 +131,24 @@ there are 3 containers of interest:
    module purge
    ```
    
+   The SLURM_snake script has the following positional arguments:
+   - a data directory to hold all data for a single run - **required**
+   - a CSV file that contains details about the image files to process - **required**
+   - the number of jobs for Snakemake to run at once - **optional defaults to 4**   
+ 
    The `SLURM_Snake` script should be run with arguments like so:
    ```
-   sbatch SLURM_Snake <data_directory> <path_to_csv>
+   sbatch SLURM_Snake <data_directory> <path_to_csv> [number_of_jobs]
    ```
    For example if you want to store the data files at the relative path of `data/list_test` and processs `List/list_test.csv` run the following:
    
    ```
    sbatch SLURM_Snake data/list_test List/list_test.csv
+   ```
+
+   To run the example with up to 8 parallel jobs run the command like so:
+   ```
+   sbatch SLURM_Snake data/list_test List/list_test.csv 8
    ```
    
    To check the process
@@ -160,3 +166,15 @@ there are 3 containers of interest:
    Metadata/
    Segmented/
    ```
+   
+   ---
+   
+   The `SLURM_Snake` script configures Snakemake to submit separate sbatch jobs for each step run.
+   Details about individual steps can be seen by running the `sacct` command.
+   
+   For example:
+   ```
+   sacct --format JobID,JobName%40,State,Elapsed,ReqMem,MaxRSS
+   ```
+   Keep in mind that `sacct` defaults to showing jobs from the current day. See [sacct docs](https://slurm.schedmd.com/sacct.html#SECTION_DEFAULT-TIME-WINDOW) for options to specify a different time range.
+

--- a/SLURM_Snake
+++ b/SLURM_Snake
@@ -2,14 +2,16 @@
 #SBATCH --account=PAS2136
 #SBATCH --job-name=segment_test
 #SBATCH --time=00:10:00
-#SBATCH --ntasks=4
 #
 # Runs Snakemake pipeline that downloads, crops, and segments images.
-# There are two required positional arguments.
+# This script has three positional arguments. The first two positional
+# arguments are required.
+#
 # Usage:
-# sbatch SLURM_Snake <WORKDIR> <INPUTCSV>
+# sbatch SLURM_Snake <WORKDIR> <INPUTCSV> [NUMJOBS]
 # - WORKDIR - Snakemake working directory - contains output files
 # - INPUTCSV - Path to input CSV file specifying images to process
+# - NUMJOBS - Optional number of jobs Snakemake will run at once, defaults to 4
 
 # Stop if a command fails (non-zero exit status)
 set -e
@@ -17,6 +19,13 @@ set -e
 # Verify command line arguments
 WORKDIR=$1
 INPUTCSV=$2
+NUMJOBS=$3
+
+# Default to running 4 jobs if not set
+if [ -z "$NUMJOBS" ]
+then
+      NUMJOBS=4
+fi
 
 # Ensures CSV path is an absolute path.
 # Otherwise snakemake will look for this file within $WORKDIR.
@@ -38,6 +47,9 @@ export TORCH_HOME=$CACHEDIR/torch
 # ensure pytorch cache directory exists
 mkdir -p $TORCH_HOME
 
+# Setup Snakemake/sbatch to use same account as this job
+export SBATCH_ACCOUNT=$SLURM_JOB_ACCOUNT
+
 # Activate Snakemake environment
 module load miniconda3/4.10.3-py37
 # Activate using source per OSC instructions
@@ -45,7 +57,8 @@ source activate snakemake
 
 # Run pipeline using Snakemake
 snakemake \
-    --cores $SLURM_NTASKS \
+    --jobs $NUMJOBS \
+    --profile slurm/ \
     --use-singularity \
     --singularity-prefix $SINGULARITY_IMAGE_DIR \
     --singularity-args "--bind $TORCH_HOME:$TORCH_HOME" \

--- a/slurm/config.yaml
+++ b/slurm/config.yaml
@@ -1,0 +1,14 @@
+cluster:
+  mkdir -p logs/{rule} &&
+  sbatch
+    --cpus-per-task={threads}
+    --mem={resources.mem_mb}
+    --job-name=sm-{rule}-{wildcards}
+    --output=logs/{rule}/{rule}-{wildcards}-%j.out
+default-resources:
+  - mem_mb=5000
+restart-times: 3
+max-jobs-per-second: 10
+max-status-checks-per-second: 1
+local-cores: 1
+latency-wait: 60


### PR DESCRIPTION
Adds a slurm/ directory containing a simple config.yaml file
that will setup Snakemake to run sbatch jobs for individual steps.
The config.yaml file is based on https://github.com/jdblischak/smk-simple-slurm.

SLURM_Snake now has an optional positional argument for the number
of jobs to run. By default SLURM_Snake will run 4 jobs.

Fixes #6